### PR TITLE
48. (5 pontos) Adicionar Cache de Respostas HTTP

### DIFF
--- a/StockApp.API/Controllers/ProductsController.cs
+++ b/StockApp.API/Controllers/ProductsController.cs
@@ -56,6 +56,7 @@ namespace StockApp.API.Controllers
         }
 
         [HttpGet]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         public async Task<IActionResult> GetAll()
         {
             var products = await _productService.GetProducts();


### PR DESCRIPTION
# 48. (5 pontos) Adicionar Cache de Respostas HTTP

## 📌 Descrição

Esta PR adiciona **cache de respostas HTTP** no endpoint de listagem de produtos, com o objetivo de melhorar o desempenho da aplicação ao reduzir chamadas repetidas ao banco de dados. A resposta será armazenada por **60 segundos** e poderá ser usada por qualquer local (cliente, proxy ou servidor).

---

## ✅ Alterações realizadas

- [x] Adicionado atributo `[ResponseCache]` no endpoint `GetAll()` do `ProductController`
- [x] Configurado o tempo de cache para `60 segundos`
- [x] Permitido armazenamento da resposta (`NoStore = false`)
- [x] Cache disponível em qualquer local (`Location = ResponseCacheLocation.Any`)
