### PR TITLE
16. (8 pontos) Adicionar Testes Unitários para o Serviço de Autenticação

### DIFF
--- a/StockApp.API/appsettings.json
+++ b/StockApp.API/appsettings.json
@@ -2,28 +2,28 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=RAFAEL\\SQLEXPRESS;Initial Catalog=avaliacao_tp2_romano;Integrated Security=True;Pooling=False;Encrypt=True;Trust Server Certificate=True"
   },
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
-    },
-    "AllowedHosts": "*",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
 
-    "JwtSettings": {
-        "SecretKey": "sua-chave-secreta-aqui-123456789",
-        "Issuer": "StockApp",
-        "Audience": "StockAppUsers",
-        "ExpirationMinutes": 60
-    },  
+  "JwtSettings": {
+    "SecretKey": "uK3r9@Lf92!qWxZ7#TpMn3$gVyBcL6^DfJqL!r29",
+    "Issuer": "StockApp",
+    "Audience": "StockAppUsers",
+    "ExpirationMinutes": 60
+  },
 
   "EmailSettings": {
     "Host": "smtp.victortesti.com",
     "Port": 587,
     "EnableSsl": true,
     "Username": "victor.testi@fatec.sp.gov.br",
-    "Password":  "Victor@123",
+    "Password": "Victor@123",
     "FromEmail": "noreply@stockapp.com",
-    "AdminEmail":  "admin@stockapp.com"
+    "AdminEmail": "admin@stockapp.com"
   }
 }

--- a/StockApp.Domain.Test/AuthServiceTest.cs
+++ b/StockApp.Domain.Test/AuthServiceTest.cs
@@ -1,0 +1,106 @@
+﻿using Moq;
+using StockApp.Application.DTOs;
+using StockApp.Application.Services;
+using StockApp.Application.Settings;
+using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+using Microsoft.Extensions.Options;
+using Xunit;
+using BCrypt.Net;
+using System;
+namespace StockApp.Domain.Test
+{
+    public class AuthServiceUnitTest
+    {
+        [Fact]
+        public async Task AuthenticateAsync_ValidCredentials_ReturnsToken()
+        {
+
+            var userRepositoryMock = new Mock<IUserRepository>();
+            var jwtSettings = new JwtSettings
+            {
+                SecretKey = "uK3r9@Lf92!qWxZ7#TpMn3$gVyBcL6^DfJqL!r29",
+                Issuer = "StockApp",
+                Audience = "StockAppUsers",
+                ExpirationMinutes = 60
+            };
+
+            var optionsMock = new Mock<IOptions<JwtSettings>>();
+
+            optionsMock.Setup(o => o.Value).Returns(jwtSettings);
+
+            var authService = new AuthService(userRepositoryMock.Object, optionsMock.Object);
+
+            userRepositoryMock.Setup(repo => repo.GetByEmailAndPasswordAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>())).ReturnsAsync(
+                new User("testuser", "testuser@user.com", BCrypt.Net.BCrypt.HashPassword("password"))
+                {
+                    Id = 1,
+                    Role = "User",
+                    Email = "testuser@user.com"
+                });
+
+            var result = await authService.AuthenticateAsync("testuser@user.com",
+            "password");
+
+            Assert.NotNull(result);
+            Assert.IsType<TokenResponseDto>(result);
+            Assert.False(string.IsNullOrEmpty(result.Token));
+        }
+        [Fact]
+        public async Task AuthenticateAsync_InvalidCredentials_ReturnsNull()
+        {
+
+            var userRepositoryMock = new Mock<IUserRepository>();
+
+            var jwtSettings = new JwtSettings
+            {
+                SecretKey = "uK3r9@Lf92!qWxZ7#TpMn3$gVyBcL6^DfJqL!r29",
+                Issuer = "StockApp",
+                Audience = "StockAppUsers",
+                ExpirationMinutes = 60
+            };
+
+            var optionsMock = new Mock<IOptions<JwtSettings>>();
+
+            optionsMock.Setup(o => o.Value).Returns(jwtSettings);
+
+            var authService = new AuthService(userRepositoryMock.Object,optionsMock.Object);
+            userRepositoryMock.Setup(repo => repo.GetByEmailAndPasswordAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>())).ReturnsAsync((User)null);
+
+            await Assert.ThrowsAsync<StockApp.Domain.Validation.AuthenticationException>(() =>
+            authService.AuthenticateAsync("teste@user.com", "testedesenha"));
+        }
+
+        [Theory]
+        [InlineData(null, "password", "Email é Obrigatório")]
+        [InlineData("testuser@user.com", null, "Senha é Obrigatória")]
+        public async Task AuthenticateAsync_InvalidInput_ThrowsDomainExceptionValidation(string email, string password, string expectedMessage)
+        {
+            
+            var userRepositoryMock = new Mock<IUserRepository>();
+
+            var jwtSettings = new JwtSettings
+            {
+                SecretKey = "uK3r9@Lf92!qWxZ7#TpMn3$gVyBcL6^DfJqL!r29",
+                Issuer = "StockApp",
+                Audience = "StockAppUsers",
+                ExpirationMinutes = 60
+            };
+
+            var optionsMock = new Mock<IOptions<JwtSettings>>();
+
+            optionsMock.Setup(o => o.Value).Returns(jwtSettings);
+
+            var authService = new AuthService(userRepositoryMock.Object, optionsMock.Object);
+
+            var exception = await Assert.ThrowsAsync<StockApp.Domain.Validation.DomainExceptionValidation>(() =>
+            authService.AuthenticateAsync(email, password));
+
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+    }
+}

--- a/StockApp.Domain.Test/StockApp.Domain.Test.csproj
+++ b/StockApp.Domain.Test/StockApp.Domain.Test.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/StockApp.Domain/Validation/AuthenticationException.cs
+++ b/StockApp.Domain/Validation/AuthenticationException.cs
@@ -16,7 +16,7 @@ namespace StockApp.Domain.Validation
         {
             if (condition)
             {
-                throw new ArgumentException(message);
+                throw new AuthenticationException(message);
             }
         }        
     }


### PR DESCRIPTION
# 16. (8 pontos) Adicionar Testes Unitários para o Serviço de Autenticação

## 📌 Descrição

Esta PR adiciona **testes unitários** ao **serviço de autenticação**, garantindo que o comportamento esperado seja validado em diferentes cenários. Os testes cobrem:

- Autenticação com credenciais válidas
- Falha ao autenticar com credenciais inválidas
- Validação de entrada nula ou incorreta

---

## ✅ Alterações realizadas

- [x] Criado o teste `AuthenticateAsync_ValidCredentials_ReturnsToken`
- [x] Mock das dependências `IUserRepository` e `IConfiguration`