### PR TITLE
26. (8 pontos) Adicionar Relatório de Estoque Baixo

### DIFF
--- a/StockApp.API/Controllers/ProductsController.cs
+++ b/StockApp.API/Controllers/ProductsController.cs
@@ -79,5 +79,12 @@ namespace StockApp.API.Controllers
                 return Ok($"{count} produtos importados com sucesso.");
             }
         }
+
+        [HttpGet("low-stock")]
+        public async Task<ActionResult<IEnumerable<ProductDTO>>> GetLowStock([FromQuery] int threshold)
+        {
+            var products = await _productService.GetLowStockAsync(threshold);
+            return Ok(products);
+        }
     }
 }

--- a/StockApp.Application/Interfaces/IProductService.cs
+++ b/StockApp.Application/Interfaces/IProductService.cs
@@ -10,5 +10,6 @@ namespace StockApp.Application.Interfaces
         Task Update(ProductDTO productDto);
         Task Remove(int? id);
         Task<IEnumerable<ProductDTO>> SearchAsync(ProductFilterDto filter);
+        Task<IEnumerable<ProductDTO>> GetLowStockAsync(int threshold);
     }
 }

--- a/StockApp.Application/Services/ProductService.cs
+++ b/StockApp.Application/Services/ProductService.cs
@@ -80,5 +80,11 @@ namespace StockApp.Application.Services
             return _mapper.Map<IEnumerable<ProductDTO>>(result);
         }
 
+        public async Task<IEnumerable<ProductDTO>> GetLowStockAsync(int threshold)
+        {
+            var productsEntity = await _productRepository.GetLowStockAsync(threshold);
+            return _mapper.Map<IEnumerable<ProductDTO>>(productsEntity);
+        }
+
     }
 }

--- a/StockApp.Domain/Interfaces/IProductRepository.cs
+++ b/StockApp.Domain/Interfaces/IProductRepository.cs
@@ -11,5 +11,7 @@ namespace StockApp.Domain.Interfaces
         Task<Product> Update(Product product);
         Task<Product> Remove(Product product);
         IQueryable<Product> Query();
+
+        Task<IEnumerable<Product>> GetLowStockAsync(int threshold);
     }
 }

--- a/StockApp.Infra.Data/Repositories/ProductRepository.cs
+++ b/StockApp.Infra.Data/Repositories/ProductRepository.cs
@@ -49,5 +49,10 @@ namespace StockApp.Infra.Data.Repositories
         {
             return _productContext.Products.Include(p => p.Category);
         }
+
+        public async Task<IEnumerable<Product>> GetLowStockAsync(int threshold)
+        {
+            return await _productContext.Products.Where(p=>p.Stock<=threshold).ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
# 26. (8 pontos) Adicionar Relatório de Estoque Baixo

## 📌 Descrição

Esta PR implementa um **endpoint** para o **relatório de produtos com estoque baixo**, permitindo identificar itens cujo nível de quantidade está abaixo de um limite mínimo definido pelo usuário. Essa funcionalidade é essencial para auxiliar na **gestão de reposição de estoque**.

---

## ✅ Alterações realizadas

- [x] Criado endpoint `GET /api/products/low-stock`
- [x] Adicionado parâmetro `threshold` via query string
- [x] Retorno de lista com produtos filtrados por estoque baixo
