### PR TITLE
85. (21 pontos) Criar Procedure em MySQL para Relatório de Compras

### DIFF
--- a/StockApp.API/Controllers/PurchaseReportController.cs
+++ b/StockApp.API/Controllers/PurchaseReportController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using StockApp.Application.Interfaces;
+using System.Threading.Tasks;
+namespace StockApp.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PurchaseReportController : ControllerBase
+    {
+        private readonly IPurchaseService _purchaseService;
+        public PurchaseReportController(IPurchaseService purchaseService)
+        {
+            _purchaseService = purchaseService;
+        }
+        [HttpGet]
+        public async Task<IActionResult> GetPurchaseReport()
+        {
+            var report = await _purchaseService.GetPurchaseReportAsync();
+            if (report == null)
+            {
+                return NotFound("Purchase report not found.");
+            }
+            return Ok(report);
+        }
+    }
+}

--- a/StockApp.API/appsettings.json
+++ b/StockApp.API/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=RAFAEL\\SQLEXPRESS;Initial Catalog=avaliacao_tp2_romano;Integrated Security=True;Pooling=False;Encrypt=True;Trust Server Certificate=True"
+    "DefaultConnection": "Data Source=DESKTOP-F68GVQT\\SQLEXPRESS;Initial Catalog=StockApp;Integrated Security=True;Trust Server Certificate=True"
   },
   "Logging": {
     "LogLevel": {

--- a/StockApp.Application/DTOs/PurchaseReportDto.cs
+++ b/StockApp.Application/DTOs/PurchaseReportDto.cs
@@ -1,0 +1,8 @@
+﻿namespace StockApp.Application.DTOs
+{
+    public class PurchaseReportDto
+    {
+        public string SupplierName { get; set; }
+        public int TotalPurchased { get; set; }
+    }
+}

--- a/StockApp.Application/Interfaces/IPurchaseService.cs
+++ b/StockApp.Application/Interfaces/IPurchaseService.cs
@@ -1,0 +1,11 @@
+using StockApp.Domain.Entities;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace StockApp.Application.Interfaces
+{
+    public interface IPurchaseService
+    {
+        Task<IEnumerable<Purchase>> GetPurchaseReportAsync();
+    }
+}

--- a/StockApp.Application/Services/PurchaseService.cs
+++ b/StockApp.Application/Services/PurchaseService.cs
@@ -1,0 +1,21 @@
+﻿using StockApp.Application.DTOs;
+using StockApp.Application.Interfaces;
+using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+namespace StockApp.Application.Services
+{
+    public class PurchaseService : IPurchaseService
+    {
+        private readonly IPurchaseRepository _purchaseRepository;
+        public PurchaseService(IPurchaseRepository purchaseRepository)
+        {
+            _purchaseRepository = purchaseRepository;
+        }
+        public async Task<IEnumerable<Purchase>> GetPurchaseReportAsync()
+        {
+            return await _purchaseRepository.GetPurchaseReportAsync();
+        }
+    }
+}

--- a/StockApp.Domain/Entities/Purchase.cs
+++ b/StockApp.Domain/Entities/Purchase.cs
@@ -12,9 +12,9 @@ namespace StockApp.Domain.Entities
         public int ProductId { get; set; }
         public int Quantity { get; set; }
         public decimal Price { get; set; }
-        public DateTime PurchaseDate { get; set; }  
+        public DateTime PurchaseDate { get; set; }
         public int SupplierId { get; set; }
-
+ 
         public Product Product { get; set; }
         public Supplier Supplier { get; set; }
     }

--- a/StockApp.Domain/Interfaces/IPurchaseRepository.cs
+++ b/StockApp.Domain/Interfaces/IPurchaseRepository.cs
@@ -1,0 +1,12 @@
+﻿using StockApp.Domain.Entities;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace StockApp.Domain.Interfaces
+{
+    public interface IPurchaseRepository
+    {
+        Task<IEnumerable<Purchase>> GetPurchaseReportAsync();
+
+    }
+}

--- a/StockApp.Infra.Data/Context/ApplicationDbContext.cs
+++ b/StockApp.Infra.Data/Context/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 
 using Microsoft.EntityFrameworkCore;
+using StockApp.Application.DTOs;
 using StockApp.Domain.Entities;
 
 namespace StockApp.Infra.Data.Context
@@ -21,6 +22,8 @@ namespace StockApp.Infra.Data.Context
         public DbSet<Purchase> Purchases { get; set; }
         public DbSet<Supplier> Supplier { get; set;}
         public DbSet<Feedback> Feedbacks { get; set; }
+
+        public DbSet<Purchase> PurchaseReports { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/StockApp.Infra.Data/Repositories/PurchaseRepository.cs
+++ b/StockApp.Infra.Data/Repositories/PurchaseRepository.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using StockApp.Application.DTOs;
+using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+using StockApp.Infra.Data.Context;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+namespace StockApp.Infra.Data.Repositories
+{
+    public class PurchaseRepository : IPurchaseRepository
+    {
+        private readonly ApplicationDbContext _context;
+        public PurchaseRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Purchase>> GetPurchaseReportAsync()
+        {
+            var result = await _context.Purchases
+                .FromSqlRaw("EXEC GetPurchaseReport")
+                .ToListAsync();
+
+            return result;
+        }
+    }
+}

--- a/StockApp.Infra.IoC/DependencyInjectionAPI.cs
+++ b/StockApp.Infra.IoC/DependencyInjectionAPI.cs
@@ -51,6 +51,9 @@ namespace StockApp.Infra.IoC
             services.AddScoped<INotificationEmailService, NotificationEmailService>();
             services.AddScoped<IUserAuditLogRepository, UserAuditLogRepository>();
             services.AddScoped<IUserAuditService, UserAuditService>();
+            services.AddScoped<IPurchaseRepository, PurchaseRepository>();
+            services.AddScoped<IPurchaseService, PurchaseService>();
+
 
             services.AddAutoMapper(typeof(DomainToDTOMappingProfile));
 


### PR DESCRIPTION
# 85. (21 pontos) Criar Procedure em SQL Server para Relatório de Compras

## 📌 Descrição

Esta PR adiciona uma **procedure** no banco de dados SQL Server chamada `GetPurchaseReport`.  
Ela gera um relatório que agrega o total de compras realizadas por fornecedor, facilitando a análise das compras consolidadas.

---

## ✅ Alterações realizadas

- [x] Criada a procedure `GetPurchaseReport` no banco de dados SQL Server
- [x] Procedure realiza `JOIN` entre tabelas `Purchases` e `Suppliers`
- [x] Agrupa e soma a quantidade total de compras por fornecedor (`SupplierName` e `TotalPurchased`)

---

## 💾 Código da Procedure

```sql
CREATE PROCEDURE getpurchasereport AS BEGIN
SELECT s.name AS suppliername,
       SUM(p.quantity) AS totalpurchased
FROM purchases p
JOIN suppliers s ON p.supplierid = s.id
GROUP BY s.name; 
END;
```

--------

**OBS:** A descrição da tarefa cita MySQL, mas conforme combinado em aula e orientações do professor, foi utilizado o SQL Server.
